### PR TITLE
Update guile.sh

### DIFF
--- a/listings/guile.sh
+++ b/listings/guile.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 cd "$(dirname "$0")"
 curl --fail --silent --show-error \
-    https://raw.githubusercontent.com/texmacs/guile/master/doc/ref/srfi-modules.texi |
+    https://cgit.git.savannah.gnu.org/cgit/guile.git/plain/doc/ref/srfi-modules.texi |
     grep -E '^\* SRFI-[0-9]+::' |
     grep -oE '[0-9]+' |
     sort -g |


### PR DESCRIPTION
Use the Savannah repository for GNU Guile version 3. The TeXMacs GNU Guile is version 1.8.8!